### PR TITLE
Add serviceWorkerPathPrepend option

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,6 +73,7 @@ module.exports = {
       fingerprint: this.app.options.fingerprint.enabled,
       plugins,
       rootURL: this._getRootURL(),
+      serviceWorkerPathPrepend: options.serviceWorkerPathPrepend,
       sourcemaps: this.app.options.sourcemaps,
       registrationDistPath: options.registrationDistPath,
       serviceWorkerFilename: options.serviceWorkerFilename

--- a/lib/service-worker-builder.js
+++ b/lib/service-worker-builder.js
@@ -89,6 +89,7 @@ module.exports = class ServiceWorkerBuilder {
       ],
       delimiters: ['{{', '}}'],
       ROOT_URL: this.options.rootURL,
+      SERVICE_WORKER_PATH_PREPEND: this.options.serviceWorkerPathPrepend,
       SERVICE_WORKER_FILENAME: this.options.serviceWorkerFilename
     };
 

--- a/service-worker-registration/index.js
+++ b/service-worker-registration/index.js
@@ -4,7 +4,7 @@ let SUCCESS_HANDLERS = [];
 let ERROR_HANDLERS = [];
 
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('{{ROOT_URL}}{{SERVICE_WORKER_FILENAME}}', { scope: '{{ROOT_URL}}' })
+  navigator.serviceWorker.register('{{SERVICE_WORKER_PATH_PREPEND}}{{ROOT_URL}}{{SERVICE_WORKER_FILENAME}}', { scope: '{{SERVICE_WORKER_PATH_PREPEND}}{{ROOT_URL}}' })
     .then(function(reg) {
       let current = Promise.resolve();
 


### PR DESCRIPTION
We use this to be able to run on a PR url, while not changing the rootURL of the application. We should get rid of this and remove the URL stripping behaviour of the proxy used for fastboot on PR's

